### PR TITLE
Feature/implement in japanese

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__serena__list_dir"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "mcp__serena__list_dir"
-    ],
-    "deny": [],
-    "ask": []
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ env/
 .env
 .env.local
 *.lock
+
+# claude
+.claude

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -10,15 +10,15 @@
 # ]
 # ///
 """
-Specify CLI - Setup tool for Specify projects
+Specify CLI - Specifyプロジェクトのセットアップツール
 
-Usage:
-    uvx specify-cli.py init <project-name>
+使用方法:
+    uvx specify-cli.py init <プロジェクト名>
     uvx specify-cli.py init --here
     
-Or install globally:
+またはグローバルインストール:
     uv tool install --from specify-cli.py specify-cli
-    specify init <project-name>
+    specify init <プロジェクト名>
     specify init --here
 """
 
@@ -64,10 +64,10 @@ BANNER = """
 ╚══════╝╚═╝     ╚══════╝ ╚═════╝╚═╝╚═╝        ╚═╝   
 """
 
-TAGLINE = "Spec-Driven Development Toolkit"
+TAGLINE = "仕様駆動開発ツールキット"
 class StepTracker:
-    """Track and render hierarchical steps without emojis, similar to Claude Code tree output.
-    Supports live auto-refresh via an attached refresh callback.
+    """階層的なステップをトラッキングして表示。Claude Codeのツリー出力と同様のスタイル。
+    アタッチされたリフレッシュコールバックによる自動更新をサポート。
     """
     def __init__(self, title: str):
         self.title = title
@@ -277,7 +277,7 @@ class BannerGroup(TyperGroup):
 
 app = typer.Typer(
     name="specify",
-    help="Setup tool for Specify spec-driven development projects",
+    help="Specify仕様駆動開発プロジェクトのセットアップツール",
     add_completion=False,
     invoke_without_command=True,
     cls=BannerGroup,
@@ -302,12 +302,12 @@ def show_banner():
 
 @app.callback()
 def callback(ctx: typer.Context):
-    """Show banner when no subcommand is provided."""
+    """サブコマンドが提供されない場合にバナーを表示。"""
     # Show banner only when no subcommand and no help flag
     # (help is handled by BannerGroup)
     if ctx.invoked_subcommand is None and "--help" not in sys.argv and "-h" not in sys.argv:
         show_banner()
-        console.print(Align.center("[dim]Run 'specify --help' for usage information[/dim]"))
+        console.print(Align.center("[dim]使用方法については 'specify --help' を実行してください[/dim]"))
         console.print()
 
 
@@ -331,12 +331,12 @@ def run_command(cmd: list[str], check_return: bool = True, capture: bool = False
 
 
 def check_tool(tool: str, install_hint: str) -> bool:
-    """Check if a tool is installed."""
+    """ツールがインストールされているか確認。"""
     if shutil.which(tool):
         return True
     else:
-        console.print(f"[yellow]⚠️  {tool} not found[/yellow]")
-        console.print(f"   Install with: [cyan]{install_hint}[/cyan]")
+        console.print(f"[yellow]⚠️  {tool} が見つかりません[/yellow]")
+        console.print(f"   インストール方法: [cyan]{install_hint}[/cyan]")
         return False
 
 
@@ -369,17 +369,17 @@ def init_git_repo(project_path: Path, quiet: bool = False) -> bool:
         original_cwd = Path.cwd()
         os.chdir(project_path)
         if not quiet:
-            console.print("[cyan]Initializing git repository...[/cyan]")
+            console.print("[cyan]Gitリポジトリを初期化中...[/cyan]")
         subprocess.run(["git", "init"], check=True, capture_output=True)
         subprocess.run(["git", "add", "."], check=True, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "Initial commit from Specify template"], check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "Specifyテンプレートからの初回コミット"], check=True, capture_output=True)
         if not quiet:
-            console.print("[green]✓[/green] Git repository initialized")
+            console.print("[green]✓[/green] Gitリポジトリを初期化しました")
         return True
         
     except subprocess.CalledProcessError as e:
         if not quiet:
-            console.print(f"[red]Error initializing git repository:[/red] {e}")
+            console.print(f"[red]Gitリポジトリの初期化エラー:[/red] {e}")
         return False
     finally:
         os.chdir(original_cwd)
@@ -393,7 +393,7 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, verb
     repo_name = "spec-kit"
     
     if verbose:
-        console.print("[cyan]Fetching latest release information...[/cyan]")
+        console.print("[cyan]最新リリース情報を取得中...[/cyan]")
     api_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases/latest"
     
     try:
@@ -402,7 +402,7 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, verb
         release_data = response.json()
     except httpx.RequestError as e:
         if verbose:
-            console.print(f"[red]Error fetching release information:[/red] {e}")
+            console.print(f"[red]リリース情報の取得エラー:[/red] {e}")
         raise typer.Exit(1)
     
     # Find the template asset for the specified AI assistant
@@ -414,8 +414,8 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, verb
     
     if not matching_assets:
         if verbose:
-            console.print(f"[red]Error:[/red] No template found for AI assistant '{ai_assistant}'")
-            console.print(f"[yellow]Available assets:[/yellow]")
+            console.print(f"[red]エラー:[/red] AIアシスタント '{ai_assistant}' 用のテンプレートが見つかりません")
+            console.print(f"[yellow]利用可能なアセット:[/yellow]")
             for asset in release_data.get("assets", []):
                 console.print(f"  - {asset['name']}")
         raise typer.Exit(1)
@@ -427,14 +427,14 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, verb
     file_size = asset["size"]
     
     if verbose:
-        console.print(f"[cyan]Found template:[/cyan] {filename}")
-        console.print(f"[cyan]Size:[/cyan] {file_size:,} bytes")
-        console.print(f"[cyan]Release:[/cyan] {release_data['tag_name']}")
+        console.print(f"[cyan]テンプレートを発見:[/cyan] {filename}")
+        console.print(f"[cyan]サイズ:[/cyan] {file_size:,} バイト")
+        console.print(f"[cyan]リリース:[/cyan] {release_data['tag_name']}")
     
     # Download the file
     zip_path = download_dir / filename
     if verbose:
-        console.print(f"[cyan]Downloading template...[/cyan]")
+        console.print(f"[cyan]テンプレートをダウンロード中...[/cyan]")
     
     try:
         with httpx.stream("GET", download_url, timeout=30, follow_redirects=True) as response:
@@ -455,7 +455,7 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, verb
                             TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
                             console=console,
                         ) as progress:
-                            task = progress.add_task("Downloading...", total=total_size)
+                            task = progress.add_task("ダウンロード中...", total=total_size)
                             downloaded = 0
                             for chunk in response.iter_bytes(chunk_size=8192):
                                 f.write(chunk)
@@ -468,12 +468,12 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, verb
     
     except httpx.RequestError as e:
         if verbose:
-            console.print(f"[red]Error downloading template:[/red] {e}")
+            console.print(f"[red]テンプレートのダウンロードエラー:[/red] {e}")
         if zip_path.exists():
             zip_path.unlink()
         raise typer.Exit(1)
     if verbose:
-        console.print(f"Downloaded: {filename}")
+        console.print(f"ダウンロード完了: {filename}")
     metadata = {
         "filename": filename,
         "size": file_size,
@@ -508,14 +508,14 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, is_curr
             tracker.error("fetch", str(e))
         else:
             if verbose:
-                console.print(f"[red]Error downloading template:[/red] {e}")
+                console.print(f"[red]テンプレートのダウンロードエラー:[/red] {e}")
         raise
     
     if tracker:
         tracker.add("extract", "Extract template")
         tracker.start("extract")
     elif verbose:
-        console.print("Extracting template...")
+        console.print("テンプレートを展開中...")
     
     try:
         # Create project directory only if not using current directory
@@ -529,7 +529,7 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, is_curr
                 tracker.start("zip-list")
                 tracker.complete("zip-list", f"{len(zip_contents)} entries")
             elif verbose:
-                console.print(f"[cyan]ZIP contains {len(zip_contents)} items[/cyan]")
+                console.print(f"[cyan]ZIPには{len(zip_contents)}個のアイテムが含まれています[/cyan]")
             
             # For current directory, extract to a temp location first
             if is_current_dir:
@@ -543,7 +543,7 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, is_curr
                         tracker.start("extracted-summary")
                         tracker.complete("extracted-summary", f"temp {len(extracted_items)} items")
                     elif verbose:
-                        console.print(f"[cyan]Extracted {len(extracted_items)} items to temp location[/cyan]")
+                        console.print(f"[cyan]{len(extracted_items)}個のアイテムを一時フォルダに展開[/cyan]")
                     
                     # Handle GitHub-style ZIP with a single root directory
                     source_dir = temp_path
@@ -553,7 +553,7 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, is_curr
                             tracker.add("flatten", "Flatten nested directory")
                             tracker.complete("flatten")
                         elif verbose:
-                            console.print(f"[cyan]Found nested directory structure[/cyan]")
+                            console.print(f"[cyan]ネストされたディレクトリ構造を発見[/cyan]")
                     
                     # Copy contents to current directory
                     for item in source_dir.iterdir():
@@ -561,7 +561,7 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, is_curr
                         if item.is_dir():
                             if dest_path.exists():
                                 if verbose and not tracker:
-                                    console.print(f"[yellow]Merging directory:[/yellow] {item.name}")
+                                    console.print(f"[yellow]ディレクトリをマージ中:[/yellow] {item.name}")
                                 # Recursively copy directory contents
                                 for sub_item in item.rglob('*'):
                                     if sub_item.is_file():
@@ -573,10 +573,10 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, is_curr
                                 shutil.copytree(item, dest_path)
                         else:
                             if dest_path.exists() and verbose and not tracker:
-                                console.print(f"[yellow]Overwriting file:[/yellow] {item.name}")
+                                console.print(f"[yellow]ファイルを上書き:[/yellow] {item.name}")
                             shutil.copy2(item, dest_path)
                     if verbose and not tracker:
-                        console.print(f"[cyan]Template files merged into current directory[/cyan]")
+                        console.print(f"[cyan]テンプレートファイルを現在のディレクトリにマージしました[/cyan]")
             else:
                 # Extract directly to project directory (original behavior)
                 zip_ref.extractall(project_path)
@@ -587,9 +587,9 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, is_curr
                     tracker.start("extracted-summary")
                     tracker.complete("extracted-summary", f"{len(extracted_items)} top-level items")
                 elif verbose:
-                    console.print(f"[cyan]Extracted {len(extracted_items)} items to {project_path}:[/cyan]")
+                    console.print(f"[cyan]{len(extracted_items)}個のアイテムを{project_path}に展開:[/cyan]")
                     for item in extracted_items:
-                        console.print(f"  - {item.name} ({'dir' if item.is_dir() else 'file'})")
+                        console.print(f"  - {item.name} ({'ディレクトリ' if item.is_dir() else 'ファイル'})")
                 
                 # Handle GitHub-style ZIP with a single root directory
                 if len(extracted_items) == 1 and extracted_items[0].is_dir():
@@ -606,14 +606,14 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, is_curr
                         tracker.add("flatten", "Flatten nested directory")
                         tracker.complete("flatten")
                     elif verbose:
-                        console.print(f"[cyan]Flattened nested directory structure[/cyan]")
+                        console.print(f"[cyan]ネストされたディレクトリ構造をフラット化しました[/cyan]")
                     
     except Exception as e:
         if tracker:
             tracker.error("extract", str(e))
         else:
             if verbose:
-                console.print(f"[red]Error extracting template:[/red] {e}")
+                console.print(f"[red]テンプレートの展開エラー:[/red] {e}")
         # Clean up project directory if created and not current directory
         if not is_current_dir and project_path.exists():
             shutil.rmtree(project_path)
@@ -630,31 +630,31 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, is_curr
             if tracker:
                 tracker.complete("cleanup")
             elif verbose:
-                console.print(f"Cleaned up: {zip_path.name}")
+                console.print(f"クリーンアップ完了: {zip_path.name}")
     
     return project_path
 
 
 @app.command()
 def init(
-    project_name: str = typer.Argument(None, help="Name for your new project directory (optional if using --here)"),
-    ai_assistant: str = typer.Option(None, "--ai", help="AI assistant to use: claude, gemini, or copilot"),
-    ignore_agent_tools: bool = typer.Option(False, "--ignore-agent-tools", help="Skip checks for AI agent tools like Claude Code"),
-    no_git: bool = typer.Option(False, "--no-git", help="Skip git repository initialization"),
-    here: bool = typer.Option(False, "--here", help="Initialize project in the current directory instead of creating a new one"),
+    project_name: str = typer.Argument(None, help="新しいプロジェクトディレクトリの名前（--here使用時はオプション）"),
+    ai_assistant: str = typer.Option(None, "--ai", help="使用するAIアシスタント: claude, gemini, または copilot"),
+    ignore_agent_tools: bool = typer.Option(False, "--ignore-agent-tools", help="Claude CodeなどのAIエージェントツールのチェックをスキップ"),
+    no_git: bool = typer.Option(False, "--no-git", help="gitリポジトリの初期化をスキップ"),
+    here: bool = typer.Option(False, "--here", help="新しいディレクトリを作成せず、現在のディレクトリでプロジェクトを初期化"),
 ):
     """
-    Initialize a new Specify project from the latest template.
+    最新のテンプレートから新しいSpecifyプロジェクトを初期化します。
     
-    This command will:
-    1. Check that required tools are installed (git is optional)
-    2. Let you choose your AI assistant (Claude Code, Gemini CLI, or GitHub Copilot)
-    3. Download the appropriate template from GitHub
-    4. Extract the template to a new project directory or current directory
-    5. Initialize a fresh git repository (if not --no-git and no existing repo)
-    6. Optionally set up AI assistant commands
+    このコマンドは以下を実行します:
+    1. 必要なツールがインストールされているか確認（gitはオプション）
+    2. AIアシスタントを選択（Claude Code、Gemini CLI、またはGitHub Copilot）
+    3. GitHubから適切なテンプレートをダウンロード
+    4. テンプレートを新しいプロジェクトディレクトリまたは現在のディレクトリに展開
+    5. 新しいgitリポジトリを初期化（--no-gitが指定されず、既存のリポジトリがない場合）
+    6. AIアシスタントコマンドをオプションで設定
     
-    Examples:
+    例:
         specify init my-project
         specify init my-project --ai claude
         specify init my-project --ai gemini
@@ -668,11 +668,11 @@ def init(
     
     # Validate arguments
     if here and project_name:
-        console.print("[red]Error:[/red] Cannot specify both project name and --here flag")
+        console.print("[red]エラー:[/red] プロジェクト名と--hereフラグを同時に指定できません")
         raise typer.Exit(1)
     
     if not here and not project_name:
-        console.print("[red]Error:[/red] Must specify either a project name or use --here flag")
+        console.print("[red]エラー:[/red] プロジェクト名を指定するか、--hereフラグを使用してください")
         raise typer.Exit(1)
     
     # Determine project directory
@@ -683,25 +683,25 @@ def init(
         # Check if current directory has any files
         existing_items = list(project_path.iterdir())
         if existing_items:
-            console.print(f"[yellow]Warning:[/yellow] Current directory is not empty ({len(existing_items)} items)")
-            console.print("[yellow]Template files will be merged with existing content and may overwrite existing files[/yellow]")
+            console.print(f"[yellow]警告:[/yellow] 現在のディレクトリは空ではありません（{len(existing_items)}個のアイテム）")
+            console.print("[yellow]テンプレートファイルは既存のコンテンツとマージされ、既存のファイルを上書きする可能性があります[/yellow]")
             
             # Ask for confirmation
-            response = typer.confirm("Do you want to continue?")
+            response = typer.confirm("続行しますか？")
             if not response:
-                console.print("[yellow]Operation cancelled[/yellow]")
+                console.print("[yellow]操作がキャンセルされました[/yellow]")
                 raise typer.Exit(0)
     else:
         project_path = Path(project_name).resolve()
         # Check if project directory already exists
         if project_path.exists():
-            console.print(f"[red]Error:[/red] Directory '{project_name}' already exists")
+            console.print(f"[red]エラー:[/red] ディレクトリ '{project_name}' は既に存在します")
             raise typer.Exit(1)
     
     console.print(Panel.fit(
-        "[bold cyan]Specify Project Setup[/bold cyan]\n"
-        f"{'Initializing in current directory:' if here else 'Creating new project:'} [green]{project_path.name}[/green]"
-        + (f"\n[dim]Path: {project_path}[/dim]" if here else ""),
+        "[bold cyan]Specifyプロジェクトセットアップ[/bold cyan]\n"
+        f"{'現在のディレクトリで初期化:' if here else '新しいプロジェクトを作成:'} [green]{project_path.name}[/green]"
+        + (f"\n[dim]パス: {project_path}[/dim]" if here else ""),
         border_style="cyan"
     ))
     
@@ -710,19 +710,19 @@ def init(
     if not no_git:
         git_available = check_tool("git", "https://git-scm.com/downloads")
         if not git_available:
-            console.print("[yellow]Git not found - will skip repository initialization[/yellow]")
+            console.print("[yellow]Gitが見つかりません - リポジトリの初期化をスキップします[/yellow]")
 
     # AI assistant selection
     if ai_assistant:
         if ai_assistant not in AI_CHOICES:
-            console.print(f"[red]Error:[/red] Invalid AI assistant '{ai_assistant}'. Choose from: {', '.join(AI_CHOICES.keys())}")
+            console.print(f"[red]エラー:[/red] 無効なAIアシスタント '{ai_assistant}'。次から選択してください: {', '.join(AI_CHOICES.keys())}")
             raise typer.Exit(1)
         selected_ai = ai_assistant
     else:
         # Use arrow-key selection interface
         selected_ai = select_with_arrows(
             AI_CHOICES, 
-            "Choose your AI assistant:", 
+            "AIアシスタントを選択:", 
             "copilot"
         )
     
@@ -731,38 +731,38 @@ def init(
         agent_tool_missing = False
         if selected_ai == "claude":
             if not check_tool("claude", "Install from: https://docs.anthropic.com/en/docs/claude-code/setup"):
-                console.print("[red]Error:[/red] Claude CLI is required for Claude Code projects")
+                console.print("[red]エラー:[/red] Claude CodeプロジェクトにはClaude CLIが必要です")
                 agent_tool_missing = True
         elif selected_ai == "gemini":
             if not check_tool("gemini", "Install from: https://github.com/google-gemini/gemini-cli"):
-                console.print("[red]Error:[/red] Gemini CLI is required for Gemini projects")
+                console.print("[red]エラー:[/red] GeminiプロジェクトにはGemini CLIが必要です")
                 agent_tool_missing = True
         # GitHub Copilot check is not needed as it's typically available in supported IDEs
         
         if agent_tool_missing:
-            console.print("\n[red]Required AI tool is missing![/red]")
-            console.print("[yellow]Tip:[/yellow] Use --ignore-agent-tools to skip this check")
+            console.print("\n[red]必要なAIツールがありません！[/red]")
+            console.print("[yellow]ヒント:[/yellow] --ignore-agent-toolsを使用してこのチェックをスキップできます")
             raise typer.Exit(1)
     
     # Download and set up project
     # New tree-based progress (no emojis); include earlier substeps
-    tracker = StepTracker("Initialize Specify Project")
+    tracker = StepTracker("Specifyプロジェクトの初期化")
     # Flag to allow suppressing legacy headings
     sys._specify_tracker_active = True
     # Pre steps recorded as completed before live rendering
-    tracker.add("precheck", "Check required tools")
-    tracker.complete("precheck", "ok")
-    tracker.add("ai-select", "Select AI assistant")
+    tracker.add("precheck", "必要なツールを確認")
+    tracker.complete("precheck", "OK")
+    tracker.add("ai-select", "AIアシスタントを選択")
     tracker.complete("ai-select", f"{selected_ai}")
     for key, label in [
-        ("fetch", "Fetch latest release"),
-        ("download", "Download template"),
-        ("extract", "Extract template"),
-        ("zip-list", "Archive contents"),
-        ("extracted-summary", "Extraction summary"),
-        ("cleanup", "Cleanup"),
-        ("git", "Initialize git repository"),
-        ("final", "Finalize")
+        ("fetch", "最新リリースを取得"),
+        ("download", "テンプレートをダウンロード"),
+        ("extract", "テンプレートを展開"),
+        ("zip-list", "アーカイブの内容"),
+        ("extracted-summary", "展開の要約"),
+        ("cleanup", "クリーンアップ"),
+        ("git", "Gitリポジトリを初期化"),
+        ("final", "完了")
     ]:
         tracker.add(key, label)
 
@@ -776,18 +776,18 @@ def init(
             if not no_git:
                 tracker.start("git")
                 if is_git_repo(project_path):
-                    tracker.complete("git", "existing repo detected")
+                    tracker.complete("git", "既存のリポジトリを検出")
                 elif git_available:
                     if init_git_repo(project_path, quiet=True):
-                        tracker.complete("git", "initialized")
+                        tracker.complete("git", "初期化完了")
                     else:
-                        tracker.error("git", "init failed")
+                        tracker.error("git", "初期化失敗")
                 else:
-                    tracker.skip("git", "git not available")
+                    tracker.skip("git", "gitが利用できません")
             else:
-                tracker.skip("git", "--no-git flag")
+                tracker.skip("git", "--no-gitフラグ")
 
-            tracker.complete("final", "project ready")
+            tracker.complete("final", "プロジェクト準備完了")
         except Exception as e:
             tracker.error("final", str(e))
             if not here and project_path.exists():
@@ -799,7 +799,7 @@ def init(
 
     # Final static tree (ensures finished state visible after Live context ends)
     console.print(tracker.render())
-    console.print("\n[bold green]Project ready.[/bold green]")
+    console.print("\n[bold green]プロジェクトの準備が完了しました。[/bold green]")
     
     # Boxed "Next steps" section
     steps_lines = []
@@ -807,27 +807,27 @@ def init(
         steps_lines.append(f"1. [bold green]cd {project_name}[/bold green]")
         step_num = 2
     else:
-        steps_lines.append("1. You're already in the project directory!")
+        steps_lines.append("1. 既にプロジェクトディレクトリにいます！")
         step_num = 2
 
     if selected_ai == "claude":
-        steps_lines.append(f"{step_num}. Open in Visual Studio Code and start using / commands with Claude Code")
-        steps_lines.append("   - Type / in any file to see available commands")
-        steps_lines.append("   - Use /spec to create specifications")
-        steps_lines.append("   - Use /plan to create implementation plans")
-        steps_lines.append("   - Use /tasks to generate tasks")
+        steps_lines.append(f"{step_num}. Visual Studio Codeで開いて、Claude Codeで / コマンドを使用開始")
+        steps_lines.append("   - 任意のファイルで / を入力して利用可能なコマンドを確認")
+        steps_lines.append("   - /spec で仕様書を作成")
+        steps_lines.append("   - /plan で実装計画を作成")
+        steps_lines.append("   - /tasks でタスクを生成")
     elif selected_ai == "gemini":
-        steps_lines.append(f"{step_num}. Use / commands with Gemini CLI")
-        steps_lines.append("   - Run gemini /spec to create specifications")
-        steps_lines.append("   - Run gemini /plan to create implementation plans")
-        steps_lines.append("   - See GEMINI.md for all available commands")
+        steps_lines.append(f"{step_num}. Gemini CLIで / コマンドを使用")
+        steps_lines.append("   - gemini /spec を実行して仕様書を作成")
+        steps_lines.append("   - gemini /plan を実行して実装計画を作成")
+        steps_lines.append("   - GEMINI.mdですべての利用可能なコマンドを確認")
     elif selected_ai == "copilot":
-        steps_lines.append(f"{step_num}. Open in Visual Studio Code and use [bold cyan]/specify[/], [bold cyan]/plan[/], [bold cyan]/tasks[/] commands with GitHub Copilot")
+        steps_lines.append(f"{step_num}. Visual Studio Codeで開いて、GitHub Copilotで [bold cyan]/specify[/], [bold cyan]/plan[/], [bold cyan]/tasks[/] コマンドを使用")
 
     step_num += 1
-    steps_lines.append(f"{step_num}. Update [bold magenta]CONSTITUTION.md[/bold magenta] with your project's non-negotiable principles")
+    steps_lines.append(f"{step_num}. [bold magenta]CONSTITUTION.md[/bold magenta] をプロジェクトの譲論の余地のない原則で更新")
 
-    steps_panel = Panel("\n".join(steps_lines), title="Next steps", border_style="cyan", padding=(1,2))
+    steps_panel = Panel("\n".join(steps_lines), title="次のステップ", border_style="cyan", padding=(1,2))
     console.print()  # blank line
     console.print(steps_panel)
     
@@ -836,31 +836,31 @@ def init(
 
 @app.command()
 def check():
-    """Check that all required tools are installed."""
+    """すべての必要なツールがインストールされているか確認します。"""
     show_banner()
-    console.print("[bold]Checking Specify requirements...[/bold]\n")
+    console.print("[bold]Specifyの要件を確認中...[/bold]\n")
     
     # Check if we have internet connectivity by trying to reach GitHub API
-    console.print("[cyan]Checking internet connectivity...[/cyan]")
+    console.print("[cyan]インターネット接続を確認中...[/cyan]")
     try:
         response = httpx.get("https://api.github.com", timeout=5, follow_redirects=True)
-        console.print("[green]✓[/green] Internet connection available")
+        console.print("[green]✓[/green] インターネット接続が利用可能です")
     except httpx.RequestError:
-        console.print("[red]✗[/red] No internet connection - required for downloading templates")
-        console.print("[yellow]Please check your internet connection[/yellow]")
+        console.print("[red]✗[/red] インターネット接続がありません - テンプレートのダウンロードに必要です")
+        console.print("[yellow]インターネット接続を確認してください[/yellow]")
     
-    console.print("\n[cyan]Optional tools:[/cyan]")
+    console.print("\n[cyan]オプションツール:[/cyan]")
     git_ok = check_tool("git", "https://git-scm.com/downloads")
     
-    console.print("\n[cyan]Optional AI tools:[/cyan]")
+    console.print("\n[cyan]オプションAIツール:[/cyan]")
     claude_ok = check_tool("claude", "Install from: https://docs.anthropic.com/en/docs/claude-code/setup")
     gemini_ok = check_tool("gemini", "Install from: https://github.com/google-gemini/gemini-cli")
     
-    console.print("\n[green]✓ Specify CLI is ready to use![/green]")
+    console.print("\n[green]✓ Specify CLIは使用可能です！[/green]")
     if not git_ok:
-        console.print("[yellow]Consider installing git for repository management[/yellow]")
+        console.print("[yellow]リポジトリ管理のためにgitのインストールを検討してください[/yellow]")
     if not (claude_ok or gemini_ok):
-        console.print("[yellow]Consider installing an AI assistant for the best experience[/yellow]")
+        console.print("[yellow]最良の体験のためにAIアシスタントのインストールを検討してください[/yellow]")
 
 
 def main():

--- a/templates/agent-file-template.md
+++ b/templates/agent-file-template.md
@@ -1,23 +1,23 @@
-# [PROJECT NAME] Development Guidelines
+# [プロジェクト名] 開発ガイドライン
 
-Auto-generated from all feature plans. Last updated: [DATE]
+すべての機能計画から自動生成。最終更新: [日付]
 
-## Active Technologies
-[EXTRACTED FROM ALL PLAN.MD FILES]
+## アクティブな技術
+[すべてのPLAN.MDファイルから抽出]
 
-## Project Structure
+## プロジェクト構造
 ```
-[ACTUAL STRUCTURE FROM PLANS]
+[計画からの実際の構造]
 ```
 
-## Commands
-[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES]
+## コマンド
+[アクティブな技術用のコマンドのみ]
 
-## Code Style
-[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE]
+## コードスタイル
+[言語固有、使用中の言語のみ]
 
-## Recent Changes
-[LAST 3 FEATURES AND WHAT THEY ADDED]
+## 最近の変更
+[最後の3つの機能とその追加内容]
 
-<!-- MANUAL ADDITIONS START -->
-<!-- MANUAL ADDITIONS END -->
+<!-- 手動追加開始 -->
+<!-- 手動追加終了 -->

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -1,41 +1,41 @@
 ---
 name: plan
-description: "Plan how to implement the specified feature. This is the second step in the Spec-Driven Development lifecycle."
+description: "指定された機能を実装する方法を計画します。これは仕様駆動開発ライフサイクルの2番目のステップです。"
 ---
 
-Plan how to implement the specified feature.
+指定された機能を実装する方法を計画します。
 
-This is the second step in the Spec-Driven Development lifecycle.
+これは仕様駆動開発ライフサイクルの2番目のステップです。
 
-Given the implementation details provided as an argument, do this:
+引数として提供された実装の詳細を基に、以下を実行します:
 
-1. Run `scripts/setup-plan.sh --json` from the repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. All future file paths must be absolute.
-2. Read and analyze the feature specification to understand:
-   - The feature requirements and user stories
-   - Functional and non-functional requirements
-   - Success criteria and acceptance criteria
-   - Any technical constraints or dependencies mentioned
+1. リポジトリルートから `scripts/setup-plan.sh --json` を実行し、FEATURE_SPEC、IMPL_PLAN、SPECS_DIR、BRANCHのJSONを解析します。今後のすべてのファイルパスは絶対パスでなければなりません。
+2. 機能仕様を読んで分析し、以下を理解します:
+   - 機能要件とユーザーストーリー
+   - 機能要件と非機能要件
+   - 成功基準と受け入れ基準
+   - 言及された技術的制約や依存関係
 
-3. Read the constitution at `/memory/constitution.md` to understand constitutional requirements.
+3. 憲法要件を理解するために `/memory/constitution.md` の憲法を読みます。
 
-4. Execute the implementation plan template:
-   - Load `/templates/implementation-plan-template.md` (already copied to IMPL_PLAN path)
-   - Set Input path to FEATURE_SPEC
-   - Run the Execution Flow (main) function steps 1-10
-   - The template is self-contained and executable
-   - Follow error handling and gate checks as specified
-   - Let the template guide artifact generation in $SPECS_DIR:
-     * Phase 0 generates research.md
-     * Phase 1 generates data-model.md, contracts/, quickstart.md
-     * Phase 2 generates tasks.md
-   - Incorporate user-provided details from arguments into Technical Context: {ARGS}
-   - Update Progress Tracking as you complete each phase
+4. 実装計画テンプレートを実行します:
+   - `/templates/implementation-plan-template.md` を読み込む（すでにIMPL_PLANパスにコピーされています）
+   - 入力パスをFEATURE_SPECに設定
+   - 実行フロー（main）関数のステップ1-10を実行
+   - テンプレートは自己完結型で実行可能
+   - 指定されたエラー処理とゲートチェックに従う
+   - テンプレートに$SPECS_DIRでアーティファクト生成をガイドさせる:
+     * フェーズ0はresearch.mdを生成
+     * フェーズ1はdata-model.md、contracts/、quickstart.mdを生成
+     * フェーズ2はtasks.mdを生成
+   - 引数からユーザー提供の詳細を技術コンテキストに組み込む: {ARGS}
+   - 各フェーズを完了するたびに進捗追跡を更新
 
-5. Verify execution completed:
-   - Check Progress Tracking shows all phases complete
-   - Ensure all required artifacts were generated
-   - Confirm no ERROR states in execution
+5. 実行が完了したことを確認:
+   - 進捗追跡がすべてのフェーズ完了を表示しているか確認
+   - すべての必要なアーティファクトが生成されたことを確認
+   - 実行にエラー状態がないことを確認
 
-6. Report results with branch name, file paths, and generated artifacts.
+6. ブランチ名、ファイルパス、生成されたアーティファクトと結果を報告します。
 
-Use absolute paths with the repository root for all file operations to avoid path issues.
+パスの問題を避けるため、すべてのファイル操作でリポジトリルートを使用した絶対パスを使用します。

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -1,17 +1,17 @@
 ---
 name: specify
-description: "Start a new feature by creating a specification and feature branch. This is the first step in the Spec-Driven Development lifecycle."
+description: "仕様書と機能ブランチを作成して新機能を開始します。これは仕様駆動開発ライフサイクルの最初のステップです。"
 ---
 
-Start a new feature by creating a specification and feature branch.
+仕様書と機能ブランチを作成して新機能を開始します。
 
-This is the first step in the Spec-Driven Development lifecycle.
+これは仕様駆動開発ライフサイクルの最初のステップです。
 
-Given the feature description provided as an argument, do this:
+引数として提供された機能の説明を基に、以下を実行します:
 
-1. Run the script `scripts/create-new-feature.sh --json "{ARGS}"` from repo root and parse its JSON output for BRANCH_NAME and SPEC_FILE. All file paths must be absolute.
-2. Load `templates/spec-template.md` to understand required sections.
-3. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
-4. Report completion with branch name, spec file path, and readiness for the next phase.
+1. リポジトリルートから `scripts/create-new-feature.sh --json "{ARGS}"` スクリプトを実行し、BRANCH_NAMEとSPEC_FILEのJSON出力を解析します。すべてのファイルパスは絶対パスでなければなりません。
+2. 必要なセクションを理解するために `templates/spec-template.md` を読み込みます。
+3. テンプレート構造を使用して仕様をSPEC_FILEに書き込み、プレースホルダーを機能の説明（引数）から導出した具体的な詳細に置き換えながら、セクションの順序と見出しを保持します。
+4. ブランチ名、仕様ファイルパス、および次のフェーズへの準備完了を報告します。
 
-Note: The script creates and checks out the new branch and initializes the spec file before writing.
+注意: スクリプトは新しいブランチを作成してチェックアウトし、書き込み前に仕様ファイルを初期化します。

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -1,63 +1,63 @@
 ---
 name: tasks
-description: "Break down the plan into executable tasks. This is the third step in the Spec-Driven Development lifecycle."
+description: "計画を実行可能なタスクに分解します。これは仕様駆動開発ライフサイクルの3番目のステップです。"
 ---
 
-Break down the plan into executable tasks.
+計画を実行可能なタスクに分解します。
 
-This is the third step in the Spec-Driven Development lifecycle.
+これは仕様駆動開発ライフサイクルの3番目のステップです。
 
-Given the context provided as an argument, do this:
+引数として提供されたコンテキストを基に、以下を実行します:
 
-1. Run `scripts/check-task-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute.
-2. Load and analyze available design documents:
-   - Always read plan.md for tech stack and libraries
-   - IF EXISTS: Read data-model.md for entities
-   - IF EXISTS: Read contracts/ for API endpoints  
-   - IF EXISTS: Read research.md for technical decisions
-   - IF EXISTS: Read quickstart.md for test scenarios
+1. リポジトリルートから `scripts/check-task-prerequisites.sh --json` を実行し、FEATURE_DIRとAVAILABLE_DOCSリストを解析します。すべてのパスは絶対パスでなければなりません。
+2. 利用可能な設計ドキュメントを読み込んで分析します:
+   - 技術スタックとライブラリのためplan.mdを常に読む
+   - 存在する場合: エンティティのためdata-model.mdを読む
+   - 存在する場合: APIエンドポイントのためcontracts/を読む
+   - 存在する場合: 技術的決定のためresearch.mdを読む
+   - 存在する場合: テストシナリオのためquickstart.mdを読む
    
-   Note: Not all projects have all documents. For example:
-   - CLI tools might not have contracts/
-   - Simple libraries might not need data-model.md
-   - Generate tasks based on what's available
+   注意: すべてのプロジェクトがすべてのドキュメントを持つわけではありません。例えば:
+   - CLIツールはcontracts/を持たないかもしれません
+   - シンプルなライブラリはdata-model.mdが不要かもしれません
+   - 利用可能なものに基づいてタスクを生成します
 
-3. Generate tasks following the template:
-   - Use `/templates/tasks-template.md` as the base
-   - Replace example tasks with actual tasks based on:
-     * **Setup tasks**: Project init, dependencies, linting
-     * **Test tasks [P]**: One per contract, one per integration scenario
-     * **Core tasks**: One per entity, service, CLI command, endpoint
-     * **Integration tasks**: DB connections, middleware, logging
-     * **Polish tasks [P]**: Unit tests, performance, docs
+3. テンプレートに従ってタスクを生成:
+   - `/templates/tasks-template.md` をベースとして使用
+   - 以下に基づいて実際のタスクで例のタスクを置き換える:
+     * **セットアップタスク**: プロジェクト初期化、依存関係、リンティング
+     * **テストタスク [P]**: 契約ごとに1つ、統合シナリオごとに1つ
+     * **コアタスク**: エンティティ、サービス、CLIコマンド、エンドポイントごとに1つ
+     * **統合タスク**: DB接続、ミドルウェア、ロギング
+     * **仕上げタスク [P]**: ユニットテスト、パフォーマンス、ドキュメント
 
-4. Task generation rules:
-   - Each contract file → contract test task marked [P]
-   - Each entity in data-model → model creation task marked [P]
-   - Each endpoint → implementation task (not parallel if shared files)
-   - Each user story → integration test marked [P]
-   - Different files = can be parallel [P]
-   - Same file = sequential (no [P])
+4. タスク生成ルール:
+   - 各契約ファイル → [P]でマークされた契約テストタスク
+   - data-model内の各エンティティ → [P]でマークされたモデル作成タスク
+   - 各エンドポイント → 実装タスク（共有ファイルの場合は並列ではない）
+   - 各ユーザーストーリー → [P]でマークされた統合テスト
+   - 異なるファイル = 並列可能 [P]
+   - 同じファイル = 順次実行（[P]なし）
 
-5. Order tasks by dependencies:
-   - Setup before everything
-   - Tests before implementation (TDD)
-   - Models before services
-   - Services before endpoints
-   - Core before integration
-   - Everything before polish
+5. 依存関係によってタスクを順序付け:
+   - すべての前にセットアップ
+   - 実装前にテスト（TDD）
+   - サービス前にモデル
+   - エンドポイント前にサービス
+   - 統合前にコア
+   - 仕上げ前にすべて
 
-6. Include parallel execution examples:
-   - Group [P] tasks that can run together
-   - Show actual Task agent commands
+6. 並列実行の例を含める:
+   - 一緒に実行できる[P]タスクをグループ化
+   - 実際のタスクエージェントコマンドを表示
 
-7. Create FEATURE_DIR/tasks.md with:
-   - Correct feature name from implementation plan
-   - Numbered tasks (T001, T002, etc.)
-   - Clear file paths for each task
-   - Dependency notes
-   - Parallel execution guidance
+7. FEATURE_DIR/tasks.mdを作成:
+   - 実装計画からの正しい機能名
+   - 番号付きタスク（T001、T002など）
+   - 各タスクの明確なファイルパス
+   - 依存関係の注記
+   - 並列実行のガイダンス
 
-Context for task generation: {ARGS}
+タスク生成のためのコンテキスト: {ARGS}
 
-The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+tasks.mdはすぐに実行可能でなければなりません - 各タスクはLLMが追加のコンテキストなしで完了できるほど具体的でなければなりません。

--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -1,96 +1,96 @@
-# Implementation Plan: [FEATURE]
+# 実装計画: [機能]
 
-**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
-**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+**ブランチ**: `[###-feature-name]` | **日付**: [日付] | **仕様書**: [リンク]
+**入力**: `/specs/[###-feature-name]/spec.md` からの機能仕様
 
-## Execution Flow (/plan command scope)
+## 実行フロー (/plan コマンドのスコープ)
 ```
-1. Load feature spec from Input path
-   → If not found: ERROR "No feature spec at {path}"
-2. Fill Technical Context (scan for NEEDS CLARIFICATION)
-   → Detect Project Type from context (web=frontend+backend, mobile=app+api)
-   → Set Structure Decision based on project type
-3. Evaluate Constitution Check section below
-   → If violations exist: Document in Complexity Tracking
-   → If no justification possible: ERROR "Simplify approach first"
-   → Update Progress Tracking: Initial Constitution Check
-4. Execute Phase 0 → research.md
-   → If NEEDS CLARIFICATION remain: ERROR "Resolve unknowns"
-5. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, or `GEMINI.md` for Gemini CLI).
-6. Re-evaluate Constitution Check section
-   → If new violations: Refactor design, return to Phase 1
-   → Update Progress Tracking: Post-Design Constitution Check
-7. Plan Phase 2 → Describe task generation approach (DO NOT create tasks.md)
-8. STOP - Ready for /tasks command
+1. 入力パスから機能仕様を読み込む
+   → 見つからない場合: エラー "{path}に機能仕様がありません"
+2. 技術コンテキストを記入（要確認をスキャン）
+   → コンテキストからプロジェクトタイプを検出（web=フロントエンド+バックエンド、mobile=アプリ+API）
+   → プロジェクトタイプに基づいて構造決定を設定
+3. 以下の憲法チェックセクションを評価
+   → 違反が存在する場合: 複雑性追跡に文書化
+   → 正当化できない場合: エラー "まずアプローチを簡素化してください"
+   → 進捗追跡を更新: 初期憲法チェック
+4. フェーズ0を実行 → research.md
+   → 要確認が残る場合: エラー "不明点を解決してください"
+5. フェーズ1を実行 → contracts、data-model.md、quickstart.md、エージェント固有のテンプレートファイル（例：Claude Codeの場合は`CLAUDE.md`、GitHub Copilotの場合は`.github/copilot-instructions.md`、Gemini CLIの場合は`GEMINI.md`）
+6. 憲法チェックセクションを再評価
+   → 新しい違反がある場合: 設計をリファクタリング、フェーズ1に戻る
+   → 進捗追跡を更新: 設計後の憲法チェック
+7. フェーズ2を計画 → タスク生成アプローチを説明（tasks.mdを作成しない）
+8. 停止 - /tasksコマンドの準備完了
 ```
 
-**IMPORTANT**: The /plan command STOPS at step 7. Phases 2-4 are executed by other commands:
-- Phase 2: /tasks command creates tasks.md
-- Phase 3-4: Implementation execution (manual or via tools)
+**重要**: /planコマンドはステップ7で停止します。フェーズ2-4は他のコマンドによって実行されます:
+- フェーズ2: /tasksコマンドがtasks.mdを作成
+- フェーズ3-4: 実装の実行（手動またはツール経由）
 
-## Summary
-[Extract from feature spec: primary requirement + technical approach from research]
+## 概要
+[機能仕様から抽出: 主要要件 + researchからの技術的アプローチ]
 
-## Technical Context
-**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
-**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
-**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
-**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
-**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
-**Project Type**: [single/web/mobile - determines source structure]  
-**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
-**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
-**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
+## 技術コンテキスト
+**言語/バージョン**: [例：Python 3.11、Swift 5.9、Rust 1.75 または 要確認]  
+**主要依存関係**: [例：FastAPI、UIKit、LLVM または 要確認]  
+**ストレージ**: [該当する場合、例：PostgreSQL、CoreData、ファイル または N/A]  
+**テスト**: [例：pytest、XCTest、cargo test または 要確認]  
+**ターゲットプラットフォーム**: [例：Linuxサーバー、iOS 15+、WASM または 要確認]
+**プロジェクトタイプ**: [single/web/mobile - ソース構造を決定]  
+**パフォーマンス目標**: [ドメイン固有、例：1000 req/s、10k lines/sec、60 fps または 要確認]  
+**制約**: [ドメイン固有、例：<200ms p95、<100MBメモリ、オフライン対応 または 要確認]  
+**スケール/スコープ**: [ドメイン固有、例：10kユーザー、1M LOC、50画面 または 要確認]
 
-## Constitution Check
-*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+## 憲法チェック
+*ゲート: フェーズ0リサーチ前に合格する必要があります。フェーズ1設計後に再チェック。*
 
-**Simplicity**:
-- Projects: [#] (max 3 - e.g., api, cli, tests)
-- Using framework directly? (no wrapper classes)
-- Single data model? (no DTOs unless serialization differs)
-- Avoiding patterns? (no Repository/UoW without proven need)
+**シンプルさ**:
+- プロジェクト数: [#] (最大3 - 例：api、cli、tests)
+- フレームワークを直接使用？（ラッパークラスなし）
+- 単一のデータモデル？（シリアライゼーションが異なる場合を除きDTOなし）
+- パターンを避けている？（実証されたニーズなしにRepository/UoWなし）
 
-**Architecture**:
-- EVERY feature as library? (no direct app code)
-- Libraries listed: [name + purpose for each]
-- CLI per library: [commands with --help/--version/--format]
-- Library docs: llms.txt format planned?
+**アーキテクチャ**:
+- すべての機能をライブラリとして？（直接のアプリコードなし）
+- リストされたライブラリ: [各ライブラリの名前 + 目的]
+- ライブラリごとのCLI: [--help/--version/--formatを持つコマンド]
+- ライブラリドキュメント: llms.txt形式が計画されている？
 
-**Testing (NON-NEGOTIABLE)**:
-- RED-GREEN-Refactor cycle enforced? (test MUST fail first)
-- Git commits show tests before implementation?
-- Order: Contract→Integration→E2E→Unit strictly followed?
-- Real dependencies used? (actual DBs, not mocks)
-- Integration tests for: new libraries, contract changes, shared schemas?
-- FORBIDDEN: Implementation before test, skipping RED phase
+**テスト（譲歩不可）**:
+- RED-GREEN-リファクタリングサイクルが強制されている？（テストは最初に失敗しなければならない）
+- Gitコミットは実装前にテストを表示？
+- 順序: Contract→Integration→E2E→Unit が厳密に従われている？
+- 実際の依存関係を使用？（モックではなく実際のDB）
+- 統合テスト: 新しいライブラリ、契約変更、共有スキーマ？
+- 禁止: テスト前の実装、REDフェーズのスキップ
 
-**Observability**:
-- Structured logging included?
-- Frontend logs → backend? (unified stream)
-- Error context sufficient?
+**オブザーバビリティ**:
+- 構造化ログが含まれている？
+- フロントエンドログ → バックエンド？（統一ストリーム）
+- エラーコンテキストは十分？
 
-**Versioning**:
-- Version number assigned? (MAJOR.MINOR.BUILD)
-- BUILD increments on every change?
-- Breaking changes handled? (parallel tests, migration plan)
+**バージョニング**:
+- バージョン番号が割り当てられている？（MAJOR.MINOR.BUILD）
+- BUILDはすべての変更で増加？
+- 破壊的変更の処理？（並列テスト、移行計画）
 
-## Project Structure
+## プロジェクト構造
 
-### Documentation (this feature)
+### ドキュメント（この機能）
 ```
 specs/[###-feature]/
-├── plan.md              # This file (/plan command output)
-├── research.md          # Phase 0 output (/plan command)
-├── data-model.md        # Phase 1 output (/plan command)
-├── quickstart.md        # Phase 1 output (/plan command)
-├── contracts/           # Phase 1 output (/plan command)
-└── tasks.md             # Phase 2 output (/tasks command - NOT created by /plan)
+├── plan.md              # このファイル（/planコマンドの出力）
+├── research.md          # フェーズ0の出力（/planコマンド）
+├── data-model.md        # フェーズ1の出力（/planコマンド）
+├── quickstart.md        # フェーズ1の出力（/planコマンド）
+├── contracts/           # フェーズ1の出力（/planコマンド）
+└── tasks.md             # フェーズ2の出力（/tasksコマンド - /planでは作成されない）
 ```
 
-### Source Code (repository root)
+### ソースコード（リポジトリルート）
 ```
-# Option 1: Single project (DEFAULT)
+# オプション1: 単一プロジェクト（デフォルト）
 src/
 ├── models/
 ├── services/
@@ -102,7 +102,7 @@ tests/
 ├── integration/
 └── unit/
 
-# Option 2: Web application (when "frontend" + "backend" detected)
+# オプション2: Webアプリケーション（"フロントエンド" + "バックエンド"が検出された場合）
 backend/
 ├── src/
 │   ├── models/
@@ -117,121 +117,121 @@ frontend/
 │   └── services/
 └── tests/
 
-# Option 3: Mobile + API (when "iOS/Android" detected)
+# オプション3: モバイル + API（"iOS/Android"が検出された場合）
 api/
-└── [same as backend above]
+└── [上記のbackendと同じ]
 
-ios/ or android/
-└── [platform-specific structure]
+ios/ または android/
+└── [プラットフォーム固有の構造]
 ```
 
-**Structure Decision**: [DEFAULT to Option 1 unless Technical Context indicates web/mobile app]
+**構造決定**: [技術コンテキストがweb/mobileアプリを示さない限り、オプション1をデフォルトとする]
 
-## Phase 0: Outline & Research
-1. **Extract unknowns from Technical Context** above:
-   - For each NEEDS CLARIFICATION → research task
-   - For each dependency → best practices task
-   - For each integration → patterns task
+## フェーズ0: アウトラインとリサーチ
+1. **上記の技術コンテキストから不明点を抽出**:
+   - 各要確認 → リサーチタスク
+   - 各依存関係 → ベストプラクティスタスク
+   - 各統合 → パターンタスク
 
-2. **Generate and dispatch research agents**:
+2. **リサーチエージェントを生成して送信**:
    ```
-   For each unknown in Technical Context:
-     Task: "Research {unknown} for {feature context}"
-   For each technology choice:
-     Task: "Find best practices for {tech} in {domain}"
+   技術コンテキストの各不明点に対して:
+     タスク: "{機能コンテキスト}のための{不明点}をリサーチ"
+   各技術選択に対して:
+     タスク: "{ドメイン}での{技術}のベストプラクティスを見つける"
    ```
 
-3. **Consolidate findings** in `research.md` using format:
-   - Decision: [what was chosen]
-   - Rationale: [why chosen]
-   - Alternatives considered: [what else evaluated]
+3. **`research.md`に調査結果を統合**（以下の形式を使用）:
+   - 決定: [選択されたもの]
+   - 根拠: [選択理由]
+   - 検討された代替案: [他に評価されたもの]
 
-**Output**: research.md with all NEEDS CLARIFICATION resolved
+**出力**: すべての要確認が解決されたresearch.md
 
-## Phase 1: Design & Contracts
-*Prerequisites: research.md complete*
+## フェーズ1: 設計と契約
+*前提条件: research.mdが完成*
 
-1. **Extract entities from feature spec** → `data-model.md`:
-   - Entity name, fields, relationships
-   - Validation rules from requirements
-   - State transitions if applicable
+1. **機能仕様からエンティティを抽出** → `data-model.md`:
+   - エンティティ名、フィールド、関係
+   - 要件からの検証ルール
+   - 該当する場合は状態遷移
 
-2. **Generate API contracts** from functional requirements:
-   - For each user action → endpoint
-   - Use standard REST/GraphQL patterns
-   - Output OpenAPI/GraphQL schema to `/contracts/`
+2. **機能要件からAPI契約を生成**:
+   - 各ユーザーアクション → エンドポイント
+   - 標準的なREST/GraphQLパターンを使用
+   - OpenAPI/GraphQLスキーマを`/contracts/`に出力
 
-3. **Generate contract tests** from contracts:
-   - One test file per endpoint
-   - Assert request/response schemas
-   - Tests must fail (no implementation yet)
+3. **契約から契約テストを生成**:
+   - エンドポイントごとに1つのテストファイル
+   - リクエスト/レスポンススキーマをアサート
+   - テストは失敗しなければならない（まだ実装なし）
 
-4. **Extract test scenarios** from user stories:
-   - Each story → integration test scenario
-   - Quickstart test = story validation steps
+4. **ユーザーストーリーからテストシナリオを抽出**:
+   - 各ストーリー → 統合テストシナリオ
+   - クイックスタートテスト = ストーリー検証ステップ
 
-5. **Update agent file incrementally** (O(1) operation):
-   - Run `/scripts/update-agent-context.sh [claude|gemini|copilot]` for your AI assistant
-   - If exists: Add only NEW tech from current plan
-   - Preserve manual additions between markers
-   - Update recent changes (keep last 3)
-   - Keep under 150 lines for token efficiency
-   - Output to repository root
+5. **エージェントファイルを段階的に更新**（O(1)操作）:
+   - あなたのAIアシスタント用に`/scripts/update-agent-context.sh [claude|gemini|copilot]`を実行
+   - 存在する場合: 現在の計画から新しい技術のみを追加
+   - マーカー間の手動追加を保持
+   - 最近の変更を更新（最後の3つを保持）
+   - トークン効率のために150行以下に保つ
+   - リポジトリルートに出力
 
-**Output**: data-model.md, /contracts/*, failing tests, quickstart.md, agent-specific file
+**出力**: data-model.md、/contracts/*、失敗するテスト、quickstart.md、エージェント固有のファイル
 
-## Phase 2: Task Planning Approach
-*This section describes what the /tasks command will do - DO NOT execute during /plan*
+## フェーズ2: タスク計画アプローチ
+*/tasksコマンドが何をするかを説明するセクション - /plan中に実行しない*
 
-**Task Generation Strategy**:
-- Load `/templates/tasks-template.md` as base
-- Generate tasks from Phase 1 design docs (contracts, data model, quickstart)
-- Each contract → contract test task [P]
-- Each entity → model creation task [P] 
-- Each user story → integration test task
-- Implementation tasks to make tests pass
+**タスク生成戦略**:
+- `/templates/tasks-template.md`をベースとして読み込む
+- フェーズ1の設計ドキュメント（契約、データモデル、クイックスタート）からタスクを生成
+- 各契約 → 契約テストタスク [P]
+- 各エンティティ → モデル作成タスク [P] 
+- 各ユーザーストーリー → 統合テストタスク
+- テストを通すための実装タスク
 
-**Ordering Strategy**:
-- TDD order: Tests before implementation 
-- Dependency order: Models before services before UI
-- Mark [P] for parallel execution (independent files)
+**順序付け戦略**:
+- TDD順序: 実装前にテスト 
+- 依存関係順序: UI前にサービス前にモデル
+- 並列実行用に[P]をマーク（独立したファイル）
 
-**Estimated Output**: 25-30 numbered, ordered tasks in tasks.md
+**推定出力**: tasks.mdに25-30個の番号付き、順序付けされたタスク
 
-**IMPORTANT**: This phase is executed by the /tasks command, NOT by /plan
+**重要**: このフェーズは/tasksコマンドによって実行され、/planではありません
 
-## Phase 3+: Future Implementation
-*These phases are beyond the scope of the /plan command*
+## フェーズ3+: 将来の実装
+*これらのフェーズは/planコマンドの範囲外です*
 
-**Phase 3**: Task execution (/tasks command creates tasks.md)  
-**Phase 4**: Implementation (execute tasks.md following constitutional principles)  
-**Phase 5**: Validation (run tests, execute quickstart.md, performance validation)
+**フェーズ3**: タスク実行（/tasksコマンドがtasks.mdを作成）  
+**フェーズ4**: 実装（憲法の原則に従ってtasks.mdを実行）  
+**フェーズ5**: 検証（テスト実行、quickstart.md実行、パフォーマンス検証）
 
-## Complexity Tracking
-*Fill ONLY if Constitution Check has violations that must be justified*
+## 複雑性追跡
+*憲法チェックに正当化が必要な違反がある場合のみ記入*
 
-| Violation | Why Needed | Simpler Alternative Rejected Because |
+| 違反 | 必要な理由 | より簡単な代替案が却下された理由 |
 |-----------|------------|-------------------------------------|
-| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
-| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |
+| [例：4番目のプロジェクト] | [現在のニーズ] | [3つのプロジェクトでは不十分な理由] |
+| [例：Repositoryパターン] | [特定の問題] | [直接DBアクセスでは不十分な理由] |
 
 
-## Progress Tracking
-*This checklist is updated during execution flow*
+## 進捗追跡
+*このチェックリストは実行フロー中に更新されます*
 
-**Phase Status**:
-- [ ] Phase 0: Research complete (/plan command)
-- [ ] Phase 1: Design complete (/plan command)
-- [ ] Phase 2: Task planning complete (/plan command - describe approach only)
-- [ ] Phase 3: Tasks generated (/tasks command)
-- [ ] Phase 4: Implementation complete
-- [ ] Phase 5: Validation passed
+**フェーズステータス**:
+- [ ] フェーズ0: リサーチ完了（/planコマンド）
+- [ ] フェーズ1: 設計完了（/planコマンド）
+- [ ] フェーズ2: タスク計画完了（/planコマンド - アプローチのみ説明）
+- [ ] フェーズ3: タスク生成（/tasksコマンド）
+- [ ] フェーズ4: 実装完了
+- [ ] フェーズ5: 検証合格
 
-**Gate Status**:
-- [ ] Initial Constitution Check: PASS
-- [ ] Post-Design Constitution Check: PASS
-- [ ] All NEEDS CLARIFICATION resolved
-- [ ] Complexity deviations documented
+**ゲートステータス**:
+- [ ] 初期憲法チェック: 合格
+- [ ] 設計後の憲法チェック: 合格
+- [ ] すべての要確認が解決済み
+- [ ] 複雑性の逸脱が文書化済み
 
 ---
-*Based on Constitution v2.1.1 - See `/memory/constitution.md`*
+*憲法 v2.1.1に基づく - `/memory/constitution.md`を参照*

--- a/templates/spec-template.md
+++ b/templates/spec-template.md
@@ -1,116 +1,109 @@
-# Feature Specification: [FEATURE NAME]
+# 機能仕様書: [機能名]
 
-**Feature Branch**: `[###-feature-name]`  
-**Created**: [DATE]  
-**Status**: Draft  
-**Input**: User description: "$ARGUMENTS"
+**機能ブランチ**: `[###-feature-name]`  
+**作成日**: [日付]  
+**ステータス**: ドラフト  
+**入力**: ユーザーの説明: "$ARGUMENTS"
 
-## Execution Flow (main)
+## 実行フロー (main)
 ```
-1. Parse user description from Input
-   → If empty: ERROR "No feature description provided"
-2. Extract key concepts from description
-   → Identify: actors, actions, data, constraints
-3. For each unclear aspect:
-   → Mark with [NEEDS CLARIFICATION: specific question]
-4. Fill User Scenarios & Testing section
-   → If no clear user flow: ERROR "Cannot determine user scenarios"
-5. Generate Functional Requirements
-   → Each requirement must be testable
-   → Mark ambiguous requirements
-6. Identify Key Entities (if data involved)
-7. Run Review Checklist
-   → If any [NEEDS CLARIFICATION]: WARN "Spec has uncertainties"
-   → If implementation details found: ERROR "Remove tech details"
-8. Return: SUCCESS (spec ready for planning)
+1. 入力からユーザーの説明を解析
+   → 空の場合: エラー "機能の説明が提供されていません"
+2. 説明から主要な概念を抽出
+   → 識別: アクター、アクション、データ、制約
+3. 不明確な各側面について:
+   → [要確認: 具体的な質問] でマーク
+4. ユーザーシナリオとテストのセクションを記入
+   → 明確なユーザーフローがない場合: エラー "ユーザーシナリオを決定できません"
+5. 機能要件を生成
+   → 各要件はテスト可能でなければならない
+   → 曖昧な要件をマーク
+6. 主要エンティティを識別（データが関与する場合）
+7. レビューチェックリストを実行
+   → [要確認] がある場合: 警告 "仕様に不確実性があります"
+   → 実装詳細が見つかった場合: エラー "技術詳細を削除してください"
+8. 戻り値: 成功（仕様は計画の準備完了）
 ```
 
 ---
 
-## ⚡ Quick Guidelines
-- ✅ Focus on WHAT users need and WHY
-- ❌ Avoid HOW to implement (no tech stack, APIs, code structure)
-- 👥 Written for business stakeholders, not developers
+## ⚡ クイックガイドライン
+- ✅ ユーザーが何を必要としているか、なぜ必要かに焦点を当てる
+- ❌ どのように実装するかは避ける（技術スタック、API、コード構造なし）
+- 👥 開発者ではなく、ビジネス関係者向けに書く
 
-### Section Requirements
-- **Mandatory sections**: Must be completed for every feature
-- **Optional sections**: Include only when relevant to the feature
-- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+### セクション要件
+- **必須セクション**: すべての機能で完成させる必要があります
+- **オプションセクション**: 機能に関連する場合のみ含める
+- セクションが適用されない場合は、完全に削除します（"N/A"として残さない）
 
-### For AI Generation
-When creating this spec from a user prompt:
-1. **Mark all ambiguities**: Use [NEEDS CLARIFICATION: specific question] for any assumption you'd need to make
-2. **Don't guess**: If the prompt doesn't specify something (e.g., "login system" without auth method), mark it
-3. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
-4. **Common underspecified areas**:
-   - User types and permissions
-   - Data retention/deletion policies  
-   - Performance targets and scale
-   - Error handling behaviors
-   - Integration requirements
-   - Security/compliance needs
-
----
-
-## User Scenarios & Testing *(mandatory)*
-
-### Primary User Story
-[Describe the main user journey in plain language]
-
-### Acceptance Scenarios
-1. **Given** [initial state], **When** [action], **Then** [expected outcome]
-2. **Given** [initial state], **When** [action], **Then** [expected outcome]
-
-### Edge Cases
-- What happens when [boundary condition]?
-- How does system handle [error scenario]?
-
-## Requirements *(mandatory)*
-
-### Functional Requirements
-- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
-- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
-- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
-- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
-- **FR-005**: System MUST [behavior, e.g., "log all security events"]
-
-*Example of marking unclear requirements:*
-- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
-- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
-
-### Key Entities *(include if feature involves data)*
-- **[Entity 1]**: [What it represents, key attributes without implementation]
-- **[Entity 2]**: [What it represents, relationships to other entities]
+### AI生成時の注意
+ユーザープロンプトからこの仕様を作成する際:
+1. **すべての曖昧さをマーク**: 仮定が必要な場合は [要確認: 具体的な質問] を使用
+2. **推測しない**: プロンプトが何かを指定していない場合（例：認証方法なしの「ログインシステム」）、マークする
+3. **テスターのように考える**: 曖昧な要件はすべて「テスト可能で明確」のチェックリスト項目に失敗すべき
+4. **一般的に仕様が不十分な領域**:
+   - ユーザータイプと権限
+   - データ保持/削除ポリシー
+   - パフォーマンス目標とスケール
+   - エラー処理の動作
+   - 統合要件
+   - セキュリティ/コンプライアンスのニーズ
 
 ---
 
-## Review & Acceptance Checklist
-*GATE: Automated checks run during main() execution*
+## ユーザーシナリオとテスト *(必須)*
 
-### Content Quality
-- [ ] No implementation details (languages, frameworks, APIs)
-- [ ] Focused on user value and business needs
-- [ ] Written for non-technical stakeholders
-- [ ] All mandatory sections completed
+### 主要ユーザーストーリー
+[平易な言葉でメインのユーザージャーニーを説明]
 
-### Requirement Completeness
-- [ ] No [NEEDS CLARIFICATION] markers remain
-- [ ] Requirements are testable and unambiguous  
-- [ ] Success criteria are measurable
-- [ ] Scope is clearly bounded
-- [ ] Dependencies and assumptions identified
+### 受け入れシナリオ
+1. **前提条件** [初期状態]、**アクション** [操作]、**期待結果** [期待される結果]
+2. **前提条件** [初期状態]、**アクション** [操作]、**期待結果** [期待される結果]
+
+### エッジケース
+- [境界条件] の場合、何が起きるか？
+- システムは [エラーシナリオ] をどのように処理するか？
+
+## 要件 *(必須)*
+
+### 機能要件
+- **FR-001**: システムは [具体的な機能、例："ユーザーがアカウントを作成できる"] 必要がある
+- **FR-002**: システムは [具体的な機能、例："メールアドレスを検証する"] 必要がある
+- **FR-003**: ユーザーは [主要な操作、例："パスワードをリセット"] できる必要がある
+- **FR-004**: システムは [データ要件、例："ユーザー設定を永続化する"] 必要がある
+- **FR-005**: システムは [動作、例："すべてのセキュリティイベントをログに記録する"] 必要がある
+
+*不明確な要件のマーク例:*
+- **FR-006**: システムは [要確認: 認証方法が指定されていません - メール/パスワード、SSO、OAuth？] でユーザーを認証する必要がある
+- **FR-007**: システムはユーザーデータを [要確認: 保持期間が指定されていません] 保持する必要がある
+
+### 主要エンティティ *(機能がデータを含む場合に含める)*
+- **[エンティティ1]**: [何を表すか、実装なしの主要属性]
+- **[エンティティ2]**: [何を表すか、他のエンティティとの関係]
 
 ---
 
-## Execution Status
-*Updated by main() during processing*
+## レビューと受け入れチェックリスト
+*ゲート: main() 実行中に自動チェックが実行されます*
 
-- [ ] User description parsed
-- [ ] Key concepts extracted
-- [ ] Ambiguities marked
-- [ ] User scenarios defined
-- [ ] Requirements generated
-- [ ] Entities identified
-- [ ] Review checklist passed
+### コンテンツ品質
+- [ ] 実装詳細なし（言語、フレームワーク、API）
+- [ ] ユーザー価値とビジネスニーズに焦点を当てている
+- [ ] 非技術的な関係者向けに書かれている
+- [ ] すべての必須セクションが完成している
+
+### 要件の完全性
+- [ ] [要確認] マーカーが残っていない
+- [ ] 要件がテスト可能で明確である
+- [ ] 成功基準が測定可能である
+- [ ] スコープが明確に定義されている
+
+### 承認署名
+- [ ] プロダクトオーナー/スポンサー承認済み
+- [ ] 技術リードレビュー済み
+- [ ] 影響を受けるチームに通知済み
 
 ---
+
+*このテンプレートは処理中にレンダリングされ、最終的な仕様書は具体的な値、要件、および確認された詳細ですべてのプレースホルダーを置き換えます。*

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -1,127 +1,127 @@
-# Tasks: [FEATURE NAME]
+# タスク: [機能名]
 
-**Input**: Design documents from `/specs/[###-feature-name]/`
-**Prerequisites**: plan.md (required), research.md, data-model.md, contracts/
+**入力**: `/specs/[###-feature-name]/` からの設計ドキュメント
+**前提条件**: plan.md（必須）、research.md、data-model.md、contracts/
 
-## Execution Flow (main)
+## 実行フロー (main)
 ```
-1. Load plan.md from feature directory
-   → If not found: ERROR "No implementation plan found"
-   → Extract: tech stack, libraries, structure
-2. Load optional design documents:
-   → data-model.md: Extract entities → model tasks
-   → contracts/: Each file → contract test task
-   → research.md: Extract decisions → setup tasks
-3. Generate tasks by category:
-   → Setup: project init, dependencies, linting
-   → Tests: contract tests, integration tests
-   → Core: models, services, CLI commands
-   → Integration: DB, middleware, logging
-   → Polish: unit tests, performance, docs
-4. Apply task rules:
-   → Different files = mark [P] for parallel
-   → Same file = sequential (no [P])
-   → Tests before implementation (TDD)
-5. Number tasks sequentially (T001, T002...)
-6. Generate dependency graph
-7. Create parallel execution examples
-8. Validate task completeness:
-   → All contracts have tests?
-   → All entities have models?
-   → All endpoints implemented?
-9. Return: SUCCESS (tasks ready for execution)
-```
-
-## Format: `[ID] [P?] Description`
-- **[P]**: Can run in parallel (different files, no dependencies)
-- Include exact file paths in descriptions
-
-## Path Conventions
-- **Single project**: `src/`, `tests/` at repository root
-- **Web app**: `backend/src/`, `frontend/src/`
-- **Mobile**: `api/src/`, `ios/src/` or `android/src/`
-- Paths shown below assume single project - adjust based on plan.md structure
-
-## Phase 3.1: Setup
-- [ ] T001 Create project structure per implementation plan
-- [ ] T002 Initialize [language] project with [framework] dependencies
-- [ ] T003 [P] Configure linting and formatting tools
-
-## Phase 3.2: Tests First (TDD) ⚠️ MUST COMPLETE BEFORE 3.3
-**CRITICAL: These tests MUST be written and MUST FAIL before ANY implementation**
-- [ ] T004 [P] Contract test POST /api/users in tests/contract/test_users_post.py
-- [ ] T005 [P] Contract test GET /api/users/{id} in tests/contract/test_users_get.py
-- [ ] T006 [P] Integration test user registration in tests/integration/test_registration.py
-- [ ] T007 [P] Integration test auth flow in tests/integration/test_auth.py
-
-## Phase 3.3: Core Implementation (ONLY after tests are failing)
-- [ ] T008 [P] User model in src/models/user.py
-- [ ] T009 [P] UserService CRUD in src/services/user_service.py
-- [ ] T010 [P] CLI --create-user in src/cli/user_commands.py
-- [ ] T011 POST /api/users endpoint
-- [ ] T012 GET /api/users/{id} endpoint
-- [ ] T013 Input validation
-- [ ] T014 Error handling and logging
-
-## Phase 3.4: Integration
-- [ ] T015 Connect UserService to DB
-- [ ] T016 Auth middleware
-- [ ] T017 Request/response logging
-- [ ] T018 CORS and security headers
-
-## Phase 3.5: Polish
-- [ ] T019 [P] Unit tests for validation in tests/unit/test_validation.py
-- [ ] T020 Performance tests (<200ms)
-- [ ] T021 [P] Update docs/api.md
-- [ ] T022 Remove duplication
-- [ ] T023 Run manual-testing.md
-
-## Dependencies
-- Tests (T004-T007) before implementation (T008-T014)
-- T008 blocks T009, T015
-- T016 blocks T018
-- Implementation before polish (T019-T023)
-
-## Parallel Example
-```
-# Launch T004-T007 together:
-Task: "Contract test POST /api/users in tests/contract/test_users_post.py"
-Task: "Contract test GET /api/users/{id} in tests/contract/test_users_get.py"
-Task: "Integration test registration in tests/integration/test_registration.py"
-Task: "Integration test auth in tests/integration/test_auth.py"
+1. 機能ディレクトリからplan.mdを読み込む
+   → 見つからない場合: エラー "実装計画が見つかりません"
+   → 抽出: 技術スタック、ライブラリ、構造
+2. オプションの設計ドキュメントを読み込む:
+   → data-model.md: エンティティを抽出 → モデルタスク
+   → contracts/: 各ファイル → 契約テストタスク
+   → research.md: 決定事項を抽出 → セットアップタスク
+3. カテゴリ別にタスクを生成:
+   → セットアップ: プロジェクト初期化、依存関係、リンティング
+   → テスト: 契約テスト、統合テスト
+   → コア: モデル、サービス、CLIコマンド
+   → 統合: DB、ミドルウェア、ロギング
+   → 仕上げ: ユニットテスト、パフォーマンス、ドキュメント
+4. タスクルールを適用:
+   → 異なるファイル = 並列実行用に[P]をマーク
+   → 同じファイル = 順次実行（[P]なし）
+   → 実装前にテスト（TDD）
+5. タスクに連番を付ける（T001、T002...）
+6. 依存関係グラフを生成
+7. 並列実行の例を作成
+8. タスクの完全性を検証:
+   → すべての契約にテストがあるか？
+   → すべてのエンティティにモデルがあるか？
+   → すべてのエンドポイントが実装されているか？
+9. 戻り値: 成功（タスクは実行準備完了）
 ```
 
-## Notes
-- [P] tasks = different files, no dependencies
-- Verify tests fail before implementing
-- Commit after each task
-- Avoid: vague tasks, same file conflicts
+## フォーマット: `[ID] [P?] 説明`
+- **[P]**: 並列実行可能（異なるファイル、依存関係なし）
+- 説明に正確なファイルパスを含める
 
-## Task Generation Rules
-*Applied during main() execution*
+## パス規約
+- **単一プロジェクト**: リポジトリルートの `src/`、`tests/`
+- **Webアプリ**: `backend/src/`、`frontend/src/`
+- **モバイル**: `api/src/`、`ios/src/` または `android/src/`
+- 以下のパスは単一プロジェクトを想定 - plan.mdの構造に基づいて調整
 
-1. **From Contracts**:
-   - Each contract file → contract test task [P]
-   - Each endpoint → implementation task
+## フェーズ3.1: セットアップ
+- [ ] T001 実装計画に従ってプロジェクト構造を作成
+- [ ] T002 [フレームワーク]の依存関係で[言語]プロジェクトを初期化
+- [ ] T003 [P] リンティングとフォーマッティングツールを設定
+
+## フェーズ3.2: テストファースト（TDD） ⚠️ 3.3の前に完了必須
+**重要: これらのテストは実装前に必ず書かれ、必ず失敗しなければならない**
+- [ ] T004 [P] tests/contract/test_users_post.pyでPOST /api/usersの契約テスト
+- [ ] T005 [P] tests/contract/test_users_get.pyでGET /api/users/{id}の契約テスト
+- [ ] T006 [P] tests/integration/test_registration.pyでユーザー登録の統合テスト
+- [ ] T007 [P] tests/integration/test_auth.pyで認証フローの統合テスト
+
+## フェーズ3.3: コア実装（テストが失敗している後のみ）
+- [ ] T008 [P] src/models/user.pyでUserモデル
+- [ ] T009 [P] src/services/user_service.pyでUserService CRUD
+- [ ] T010 [P] src/cli/user_commands.pyでCLI --create-user
+- [ ] T011 POST /api/usersエンドポイント
+- [ ] T012 GET /api/users/{id}エンドポイント
+- [ ] T013 入力検証
+- [ ] T014 エラー処理とロギング
+
+## フェーズ3.4: 統合
+- [ ] T015 UserServiceをDBに接続
+- [ ] T016 認証ミドルウェア
+- [ ] T017 リクエスト/レスポンスのロギング
+- [ ] T018 CORSとセキュリティヘッダー
+
+## フェーズ3.5: 仕上げ
+- [ ] T019 [P] tests/unit/test_validation.pyで検証のユニットテスト
+- [ ] T020 パフォーマンステスト（<200ms）
+- [ ] T021 [P] docs/api.mdを更新
+- [ ] T022 重複を削除
+- [ ] T023 manual-testing.mdを実行
+
+## 依存関係
+- 実装（T008-T014）前にテスト（T004-T007）
+- T008はT009、T015をブロック
+- T016はT018をブロック
+- 仕上げ（T019-T023）前に実装
+
+## 並列実行の例
+```
+# T004-T007を一緒に起動:
+タスク: "tests/contract/test_users_post.pyでPOST /api/usersの契約テスト"
+タスク: "tests/contract/test_users_get.pyでGET /api/users/{id}の契約テスト"
+タスク: "tests/integration/test_registration.pyで登録の統合テスト"
+タスク: "tests/integration/test_auth.pyで認証の統合テスト"
+```
+
+## 注意事項
+- [P]タスク = 異なるファイル、依存関係なし
+- 実装前にテストが失敗することを確認
+- 各タスク後にコミット
+- 避ける: 曖昧なタスク、同じファイルの競合
+
+## タスク生成ルール
+*main()実行中に適用*
+
+1. **契約から**:
+   - 各契約ファイル → 契約テストタスク [P]
+   - 各エンドポイント → 実装タスク
    
-2. **From Data Model**:
-   - Each entity → model creation task [P]
-   - Relationships → service layer tasks
+2. **データモデルから**:
+   - 各エンティティ → モデル作成タスク [P]
+   - 関係 → サービスレイヤータスク
    
-3. **From User Stories**:
-   - Each story → integration test [P]
-   - Quickstart scenarios → validation tasks
+3. **ユーザーストーリーから**:
+   - 各ストーリー → 統合テスト [P]
+   - クイックスタートシナリオ → 検証タスク
 
-4. **Ordering**:
-   - Setup → Tests → Models → Services → Endpoints → Polish
-   - Dependencies block parallel execution
+4. **順序付け**:
+   - セットアップ → テスト → モデル → サービス → エンドポイント → 仕上げ
+   - 依存関係は並列実行をブロック
 
-## Validation Checklist
-*GATE: Checked by main() before returning*
+## 検証チェックリスト
+*ゲート: 返す前にmain()でチェック*
 
-- [ ] All contracts have corresponding tests
-- [ ] All entities have model tasks
-- [ ] All tests come before implementation
-- [ ] Parallel tasks truly independent
-- [ ] Each task specifies exact file path
-- [ ] No task modifies same file as another [P] task
+- [ ] すべての契約に対応するテストがある
+- [ ] すべてのエンティティにモデルタスクがある
+- [ ] すべてのテストが実装前に来る
+- [ ] 並列タスクが本当に独立している
+- [ ] 各タスクが正確なファイルパスを指定している
+- [ ] [P]タスクが同じファイルを変更しない


### PR DESCRIPTION
This pull request translates all user-facing strings in the `src/specify_cli/__init__.py` file from English to Japanese, making the Specify CLI tool more accessible to Japanese-speaking users. The changes cover help texts, error messages, command descriptions, and runtime output, ensuring a consistent Japanese experience throughout the CLI.

**Localization of CLI output and documentation:**

* Updated the module docstring, help texts, and usage instructions to Japanese, including command examples and installation directions. [[1]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL13-R21) [[2]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL280-R280) [[3]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL633-R657)
* Translated all runtime console messages, error/warning outputs, and progress indicators to Japanese, including messages for git initialization, template download/extraction, and file/directory operations. [[1]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL372-R382) [[2]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL396-R396) [[3]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL430-R437) [[4]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL458-R458) [[5]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL471-R476) [[6]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL511-R518) [[7]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL532-R532) [[8]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL546-R546) [[9]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL556-R564) [[10]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL576-R579) [[11]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL590-R592) [[12]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL609-R616)
* Localized error handling and confirmation prompts, such as argument validation, directory existence checks, and overwrite warnings, to Japanese. [[1]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL671-R675) [[2]](diffhunk://#diff-8e3e8dfe8740d05f4d06dd457ea293ec88ac0ecc9bba6eb182f0f767db67ce9eL686-R704)
* Translated option descriptions and command docstrings for the `init` command, including the step-by-step explanation of what the command does.
* Changed the CLI tagline and class docstrings to Japanese, ensuring all documentation within the CLI matches the localized output.

These changes collectively provide a fully Japanese experience for users of the Specify CLI tool.